### PR TITLE
Tag now acceptable parameter for getting diff of files.

### DIFF
--- a/TdsGlobal.config
+++ b/TdsGlobal.config
@@ -20,6 +20,8 @@
     <!-- Custom Build Extensions Properties - examples given-->
     <!--<CustomGitDeltaDeploy>True</CustomGitDeltaDeploy>-->
     <!--<LastDeploymentGitCommitID>50e42cceced5661dcb8360d010189b8163558e24</LastDeploymentGitCommitID>-->
+    <!--<LastDeploymentGitTagName>ProductionRelease</LastDeploymentGitTagName>-->
+    <!--<CullProjectFiles>True</CullProjectFiles>-->
     <!-- Default Delta Deploy - example of passing the date to the default delta deploy feature. (This is only for the default delta deploy feature. It is not used for the custom git delta deploy. -->
     <!--<IncludeItemsChangedAfter>2016-03-21</IncludeItemsChangedAfter>-->
     <!-- Default Delta Deploy - example of passing in a relative date (1 week ago) to the default delta deploy feature. -->

--- a/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
+++ b/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
@@ -83,25 +83,33 @@
     </ReadLinesFromFile>
     <Message Condition="'$(LastDeploymentGitCommitID)' != ''" 
              Importance="normal" 
-             Text="Last Deployment Git Commit ID is :- $(LastDeploymentGitCommitID)" />
-    <Message Condition="'$(LastDeploymentGitCommitID)' == ''"
+             Text="Last Deployment Git Commit ID is : $(LastDeploymentGitCommitID)" />
+    <Message Condition="'$(LastDeploymentGitCommitID)' == '' and '$(LastDeploymentGitTagName)' == ''"
              Importance="normal" 
-             Text="Last Deployment Git Commit ID does not exist. This will mean the entire TDS project will be deployed without using the custom git delta deploy feature." />
-
+             Text="Neither Last Deployment Git Commit ID or Last Deployment Git Tag Name exist. The entire TDS project will be deployed without using the custom git delta deploy feature." />
+	<Message Condition="'$(LastDeploymentGitTagName)' != ''" 
+             Importance="normal" 
+             Text="Last Deployment Git Tag Name is : $(LastDeploymentGitTagName)" />
+	
     <!-- Retrieve the git commit ID of the current git repo and store it in the GitCurrentCommitID property. -->
-    <Exec Condition="$(GitExists) and '$(LastDeploymentGitCommitID)' != ''"
+    <Exec Condition="$(GitExists) and ('$(LastDeploymentGitCommitID)' != '' or '$(LastDeploymentGitTagName)' != '')"
           Command="git rev-parse HEAD" Outputs="$(GitCurrentCommitID)" WorkingDirectory="$(SolutionDir)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCurrentCommitID" />
     </Exec>
     <Message Condition="'$(GitCurrentCommitID)' != ''" 
-             Importance="normal" Text="Current Git Commit is:- $(GitCurrentCommitID)" />
+             Importance="normal" Text="Current Git Commit is: $(GitCurrentCommitID)" />
 
     <MakeDir Condition="!Exists('$(MSBuildProjectDirectory)/Report')"
          Directories="$(MSBuildProjectDirectory)/Report" />
     
+	<PropertyGroup>
+      <PrevIdentifier Condition="'$(LastDeploymentGitTagName)' != ''">$(LastDeploymentGitTagName)</PrevIdentifier>
+      <PrevIdentifier Condition="'$(LastDeploymentGitTagName)' == '' and '$(LastDeploymentGitCommitID)' != ''">$(LastDeploymentGitCommitID)</PrevIdentifier>
+    </PropertyGroup>
+	
     <!-- Discover the .item files that have changed in between the current commit that this repo is at and the last deployment of this project -->
-    <Exec Condition="$(GitExists) and '$(LastDeploymentGitCommitID)' != '' and '$(GitCurrentCommitID)' != ''" 
-          Command="git diff -r --name-only --no-commit-id $(LastDeploymentGitCommitID)..$(GitCurrentCommitID) &quot;*.item&quot; &gt; $(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" Outputs="$(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" WorkingDirectory="$(SolutionDir)" />
+    <Exec Condition="$(GitExists) and '$(PrevIdentifier)' != '' and '$(GitCurrentCommitID)' != ''" 
+          Command="git diff -r --name-only --no-commit-id --no-renames $(PrevIdentifier)..$(GitCurrentCommitID) &quot;*.item&quot; &gt; $(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" Outputs="$(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" WorkingDirectory="$(SolutionDir)" />
   </Target>
 
   <!-- Cull down the deployable items by checking if they exist in the ChangedItemFiles.txt file. -->
@@ -124,23 +132,21 @@
 
     <Exec Condition="$(GitExists)"
           Command="git rev-parse HEAD &gt; $(MSBuildProjectDirectory)/Report/LastDeploymentGitCommitId.txt" Outputs="$(MSBuildProjectDirectory)/Report/LastDeploymentGitCommitId.txt" WorkingDirectory="$(SolutionDir)"  />
-  </Target>
+    </Target>
 
-  <Target Name="AfterSitecoreBuild" Condition="'$(CustomGitDeltaDeploy)' == 'True' and '$(CullProjectFiles)' == 'True'">
-	  <!-- called to set LastDeploymentGitCommitID variable -->
-    <CallTarget Targets="GitDiff"/>
-	
+    <Target Name="AfterSitecoreBuild" Condition="'$(CullProjectFiles)' == 'True'" DependsOnTargets="GitDiff">
 	  <!-- list all files -->
+	  <Message Importance="normal" Text="git ls-files --full-name &gt; &quot;$(MSBuildProjectDirectory)/Report/AllFiles.$(MSBuildProjectName).txt&quot;" />
 	  <Exec Command="git ls-files --full-name &gt; &quot;$(MSBuildProjectDirectory)/Report/AllFiles.$(MSBuildProjectName).txt&quot;" Outputs="$(MSBuildProjectDirectory)/Report/AllFiles.$(MSBuildProjectName).txt" WorkingDirectory="$(SolutionDir)" />
-	
+
 	  <!-- list changed files -->
-	  <Exec Command="git diff --name-only $(LastDeploymentGitCommitID)..$(GitCurrentCommitID) &gt; &quot;$(MSBuildProjectDirectory)/Report/DiffFiles.$(MSBuildProjectName).txt&quot;" Outputs="$(MSBuildProjectDirectory)/Report/DiffFiles.$(MSBuildProjectName).txt" WorkingDirectory="$(SolutionDir)" />
+	  <Message Importance="normal" Text="git diff --name-only $(PrevIdentifier)..$(GitCurrentCommitID) &gt; &quot;$(MSBuildProjectDirectory)/Report/DiffFiles.$(MSBuildProjectName).txt&quot;" />
+	  <Exec Command="git diff --name-only $(PrevIdentifier)..$(GitCurrentCommitID) &gt; &quot;$(MSBuildProjectDirectory)/Report/DiffFiles.$(MSBuildProjectName).txt&quot;" Outputs="$(MSBuildProjectDirectory)/Report/DiffFiles.$(MSBuildProjectName).txt" WorkingDirectory="$(SolutionDir)" />
 	
 	  <!-- aggregate into single file listing only unchanged files -->
+	  <Message Importance="normal" Text="findstr /vig:&quot;$(MSBuildProjectDirectory)\Report\DiffFiles.$(MSBuildProjectName).txt&quot; &quot;$(MSBuildProjectDirectory)\Report\AllFiles.$(MSBuildProjectName).txt&quot; &gt; &quot;$(MSBuildProjectDirectory)\Report\Unchanged.$(MSBuildProjectName).txt&quot;" />
 	  <Exec Command="findstr /vig:&quot;$(MSBuildProjectDirectory)\Report\DiffFiles.$(MSBuildProjectName).txt&quot; &quot;$(MSBuildProjectDirectory)\Report\AllFiles.$(MSBuildProjectName).txt&quot; &gt; &quot;$(MSBuildProjectDirectory)\Report\Unchanged.$(MSBuildProjectName).txt&quot;" Outputs="$(MSBuildProjectDirectory)\Report\Unchanged.$(MSBuildProjectName).txt" WorkingDirectory="$(SolutionDir)" />
-	
-	  <CullFilesFromProject OutputPath="$(_OutputPath)" UnchangedFiles="$(MSBuildProjectDirectory)/Report/Unchanged.$(MSBuildProjectName).txt">
-	    <Output PropertyName="DebugMessage" TaskParameter="DebugMessage"/>
-	  </CullFilesFromProject>
+
+	  <CullFilesFromProject OutputPath="$(_OutputPath)" UnchangedFiles="$(MSBuildProjectDirectory)/Report/Unchanged.$(MSBuildProjectName).txt" />
   </Target>
 </Project>

--- a/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Tasks/Filters/CullFilesFromProject.cs
+++ b/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Tasks/Filters/CullFilesFromProject.cs
@@ -57,7 +57,7 @@ namespace Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.Tasks.Filters
                 Log.LogCommandLine("CullFilesFromProject :: Deleted file: " + file);
             }
 
-            foreach (var directory in Directory.EnumerateDirectories(normalizedOutputDir, "*", SearchOption.AllDirectories))
+            foreach (var directory in Directory.EnumerateDirectories(normalizedOutputDir, "*", SearchOption.AllDirectories).OrderByDescending(i => i.Length))
             {
                 if (Directory.GetFiles(directory).Length != 0 || Directory.GetDirectories(directory).Length != 0)
                     continue;

--- a/src/_Nuget/build/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
+++ b/src/_Nuget/build/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
@@ -109,7 +109,7 @@
 	
     <!-- Discover the .item files that have changed in between the current commit that this repo is at and the last deployment of this project -->
     <Exec Condition="$(GitExists) and '$(PrevIdentifier)' != '' and '$(GitCurrentCommitID)' != ''" 
-          Command="git diff -r --name-only --no-commit-id --no-renames $(PrevIdentifier)..$(GitCurrentCommitID) &quot;*.item&quot; &gt; $(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" Outputs="$(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" WorkingDirectory="$(SolutionDir)" />
+          Command="git diff -r --name-only --no-commit-id $(PrevIdentifier)..$(GitCurrentCommitID) &quot;*.item&quot; &gt; $(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" Outputs="$(MSBuildProjectDirectory)/Report/ChangedItemFiles.txt" WorkingDirectory="$(SolutionDir)" />
   </Target>
 
   <!-- Cull down the deployable items by checking if they exist in the ChangedItemFiles.txt file. -->


### PR DESCRIPTION
Added ability to pass in a Tag as opposed to a commit hash. This opens up the possibility of a release being tagged when it goes to production, thus allowing the delta deploy to pull changes from the most recent tag, essentially automating the process.