### PR TITLE
Added step to push lastcommitid.txt to output directory

### DIFF
--- a/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
+++ b/src/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy/Hedgehog.TDS.BuildExtensions.GitDeltaDeploy.targets
@@ -93,6 +93,9 @@
           Command="git rev-parse HEAD" Outputs="$(GitCurrentCommitID)" WorkingDirectory="$(SolutionDir)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCurrentCommitID" />
     </Exec>
+
+    <CallTarget Condition="$(GitExists) and '$(CustomGitDeltaDeploy)' == 'True'" Targets="OutputLastCommitId"/>
+	
     <Message Condition="'$(GitCurrentCommitID)' != ''" 
              Importance="normal" Text="Current Git Commit is:- $(GitCurrentCommitID)" />
 
@@ -142,5 +145,19 @@
 	  <CullFilesFromProject OutputPath="$(_OutputPath)" UnchangedFiles="$(MSBuildProjectDirectory)/Report/Unchanged.$(MSBuildProjectName).txt">
 	    <Output PropertyName="DebugMessage" TaskParameter="DebugMessage"/>
 	  </CullFilesFromProject>
+  </Target>
+
+  <Target Name="OutputLastCommitId" Condition="'$(CustomGitDeltaDeploy)' == 'True'">
+	<PropertyGroup>
+      <DeltaFolder Condition="'$(OutDir)' != '$(OutputPath)' and '$(OutDir)' != ''">$(OutDir)Delta</DeltaFolder>
+      <DeltaFolder Condition="'$(OutDir)' == '$(OutputPath)' or '$(OutDir)' == ''">$(MSBuildProjectDirectory)\bin\Delta</DeltaFolder>
+    </PropertyGroup>
+  
+    <Message Importance="normal" Text="Storing the LastDeploymentGitCommitId.txt file to build output directory: $(DeltaFolder)." />
+
+	<MakeDir Condition="!Exists('$(DeltaFolder)')"
+         Directories="$(DeltaFolder)" />
+	
+    <Exec Command="git rev-parse HEAD &gt; $(DeltaFolder)\LastDeploymentGitCommitId.txt" Outputs="$(DeltaFolder)\LastDeploymentGitCommitId.txt" WorkingDirectory="$(SolutionDir)"  />
   </Target>
 </Project>


### PR DESCRIPTION
By copying the commit ID of the build to the output directory, it provides the ability to know exactly which commit is being released to a server.  This let's the release step perform actions with the given commit.  It could: tag the repo at the given hash, it could set a variable (think VSTS or Jenkins).  There are many possibilities.